### PR TITLE
Upscale ec2 volume size to 100 Gib for artifactory requirements

### DIFF
--- a/infra/modules/artifactory/main.tf
+++ b/infra/modules/artifactory/main.tf
@@ -140,4 +140,7 @@ resource "aws_instance" "artifactory_instance" {
   iam_instance_profile   = aws_iam_instance_profile.iam_instance_profile.name
   key_name               = aws_key_pair.key_pair.key_name
   tags                   = merge(var.tags, { Name = var.artifactory_server_name })
+  root_block_device {
+    volume_size = 100
+  }
 }


### PR DESCRIPTION
The testing with the artifactory requires more space to push and test heavy artifacts.
In absence of any concrete requirement we decided to scale it from 10 to 100 Gib